### PR TITLE
add conf.enable_test into build_config.rb

### DIFF
--- a/run_test.rb
+++ b/run_test.rb
@@ -21,6 +21,7 @@ end
 MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
+  conf.enable_test
 
   conf.gem File.expand_path(File.dirname(__FILE__))
 end


### PR DESCRIPTION
`ruby run_test.rb all test` doesn't execute tests.