### PR TITLE
use NotImplementedError instead of RuntimeError for Win

### DIFF
--- a/src/dir.c
+++ b/src/dir.c
@@ -217,7 +217,7 @@ mrb_value
 mrb_dir_seek(mrb_state *mrb, mrb_value self)
 {
   #if defined(_WIN32) || defined(_WIN64) || defined(__android__)
-  mrb_raise(mrb, E_RUNTIME_ERROR, "dirseek() unreliable on Win platforms");
+  mrb_raise(mrb, E_NOTIMP_ERROR, "dirseek() unreliable on Win platforms");
   return self;
   #else
   struct mrb_dir *mdir;
@@ -238,7 +238,7 @@ mrb_value
 mrb_dir_tell(mrb_state *mrb, mrb_value self)
 {
   #if defined(_WIN32) || defined(_WIN64) || defined(__android__)
-  mrb_raise(mrb, E_RUNTIME_ERROR, "dirtell() unreliable on Win platforms");
+  mrb_raise(mrb, E_NOTIMP_ERROR, "dirtell() unreliable on Win platforms");
   return mrb_fixnum_value(0);
   #else
   struct mrb_dir *mdir;


### PR DESCRIPTION
These errors and `E_IO_ERROR` should be distinguishable.