### PR TITLE
fix test for windows

### DIFF
--- a/test/dir.rb
+++ b/test/dir.rb
@@ -108,19 +108,27 @@ end
 
 assert('Dir#tell') do
   n = nil
-  Dir.open(DirTest.sandbox) { |d|
-    n = d.tell
-  }
-  assert_true n.is_a? Integer
+  begin
+    Dir.open(DirTest.sandbox) { |d|
+      n = d.tell
+    }
+    assert_true n.is_a? Integer
+  rescue NotImplementedError => e
+    skip e.message
+  end
 end
 
 assert('Dir#seek') do
   d1 = Dir.open(DirTest.sandbox)
   d1.read
-  n = d1.tell
-  d1.read
-  d2 = d1.seek(n)
-  assert_equal d1, d2
+  begin
+    n = d1.tell
+    d1.read
+    d2 = d1.seek(n)
+    assert_equal d1, d2
+  rescue NotImplementedError => e
+    skip e.message
+  end
 end
 
 assert('DirTest.teardown') do

--- a/test/dirtest.c
+++ b/test/dirtest.c
@@ -28,10 +28,17 @@ mrb_dirtest_setup(mrb_state *mrb, mrb_value klass)
   mrb_cv_set(mrb, klass, mrb_intern_cstr(mrb, "pwd"), mrb_str_new_cstr(mrb, buf));
 
   /* create sandbox */
+#if defined(_WIN32) || defined(_WIN64)
+  snprintf(buf, sizeof(buf), "%s\\mruby-dir-test.XXXXXX", _getcwd(NULL,0));
+  if ((mktemp(buf) == NULL) || mkdir(buf) != 0) {
+    mrb_raisef(mrb, E_RUNTIME_ERROR, "mkdtemp(%S) failed", mrb_str_new_cstr(mrb, buf));
+  }
+#else
   snprintf(buf, sizeof(buf), "%s/mruby-dir-test.XXXXXX", P_tmpdir);
   if (mkdtemp(buf) == NULL) {
     mrb_raisef(mrb, E_RUNTIME_ERROR, "mkdtemp(%S) failed", mrb_str_new_cstr(mrb, buf));
   }
+#endif
   s = mrb_str_new_cstr(mrb, buf);
   mrb_cv_set(mrb, klass, mrb_intern_cstr(mrb, "sandbox"), s);
 
@@ -42,12 +49,20 @@ mrb_dirtest_setup(mrb_state *mrb, mrb_value klass)
   }
   
   /* make some directories in the sandbox */
+#if defined(_WIN32) || defined(_WIN64)
+  if (mkdir(aname) == -1) {
+#else
   if (mkdir(aname, 0) == -1) {
+#endif
     chdir("..");
     rmdir(buf);
     mrb_raisef(mrb, E_RUNTIME_ERROR, "mkdir(%S) failed", mrb_str_new_cstr(mrb, aname));
   }
+#if defined(_WIN32) || defined(_WIN64)
+  if (mkdir(bname) == -1) {
+#else
   if (mkdir(bname, 0) == -1) {
+#endif
     rmdir(aname);
     chdir("..");
     rmdir(buf);


### PR DESCRIPTION
With this patch, mruby-dir on Windows passes the test.

* `_mkdir()` has only one argument
* use `mktemp` && `mkdir` instead of `mkdtemp`
* use `_getcwd` instead of `P_tmpdir` (sandbox is on current dir)
* test for `Dir#tell` and `Dir#seek`: skip when `NotImplementedError` is raised